### PR TITLE
Made 'location' compatible with both string and longitude/latitude

### DIFF
--- a/library/forecastwrapper.py
+++ b/library/forecastwrapper.py
@@ -145,6 +145,7 @@ class Weather_Days(Weather):
                  start,
                  end = None,
                  tz = None,
+                 averageTemperature = True,
                  heatingDegreeDays = True,
                  heatingBaseTemps = [16.5],
                  coolingDegreeDays = False,
@@ -167,6 +168,8 @@ class Weather_Days(Weather):
                 The lookup always happens in the timezone of the location
                 tz specifies the timezone of the response.
                 If none, tz is the timezone of the location
+            averageTemperature: bool (optional, default: True)
+                Include automatic calculation of average temperature from hourly data
             heatingDegreeDays: bool (optional, default: True)
                 Add heating degree days to the dataframe
             heatingBaseTemps: list of numbers (optional, default 16.5)
@@ -176,6 +179,8 @@ class Weather_Days(Weather):
             coolingBaseTemps: list of numbers (optional, default 18)
                 List of possible base temperatures for which to calculate cooling degree days
         """
+
+        self.averageTemperature = averageTemperature
 
         #we need data from 2 days earlier to calculate degree days
         if heatingDegreeDays or coolingDegreeDays:
@@ -208,9 +213,10 @@ class Weather_Days(Weather):
         forecast = forecastio.load_forecast(self.api_key, self.location.latitude, self.location.longitude, date)
         day_data = forecast.daily().data[0].d
 
-        #calculate average temperature and add to day_data
-        avg_temp = self._get_daily_avg(forecast = forecast, key = 'temperature')
-        day_data.update({'temperature':avg_temp})
+        if self.averageTemperature:
+            #calculate average temperature and add to day_data
+            avg_temp = self._get_daily_avg(forecast = forecast, key = 'temperature')
+            day_data.update({'temperature':avg_temp})
 
         #convert to a single row in a dataframe and return
         daylist = [pd.Series(day_data)]

--- a/scripts/Demo_Forecast.io.ipynb
+++ b/scripts/Demo_Forecast.io.ipynb
@@ -120,7 +120,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
@@ -168,6 +168,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Location can also be coördinates"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -175,7 +182,7 @@
    },
    "outputs": [],
    "source": [
-    "WHGent = forecastwrapper.Weather_Hours(api_key=api_key, location='Gent', \n",
+    "WHBrussel = forecastwrapper.Weather_Hours(api_key=api_key, location=[50.8503396, 4.3517103], \n",
     "                                   start=pd.Timestamp('20150916'), end=pd.Timestamp('20150918'))\n",
     "WHBoutersem = forecastwrapper.Weather_Hours(api_key=api_key, location='Kapelstraat 1, 3370 Boutersem', \n",
     "                                   start=pd.Timestamp('20150916'), end=pd.Timestamp('20150918'))"
@@ -189,7 +196,7 @@
    },
    "outputs": [],
    "source": [
-    "df_combined = pd.merge(WHGent.df, WHBoutersem.df, suffixes=('_Gent', '_Boutersem'), \n",
+    "df_combined = pd.merge(WHBrussel.df, WHBoutersem.df, suffixes=('_Brussel', '_Boutersem'), \n",
     "                           left_index=True, right_index=True)"
    ]
   },


### PR DESCRIPTION
We needed a way to pass latitude/longitude to the forecast constructor instead of a String for which we then have to perform a lookup. Instead of adding a new argument I thought it would be best to check if ‘location’ is a string or not.