### PR TITLE
ForecastWrapperV2

### DIFF
--- a/library/forecastwrapper.py
+++ b/library/forecastwrapper.py
@@ -121,6 +121,15 @@ class Weather(object):
         tz = self.geolocator.timezone((self.location.latitude,self.location.longitude))
         return tz.zone
 
+    def get_weather_ts(self, date):
+        """
+        Abstract
+        Get one single row of the final dataframe, representing data from a single day.
+        :param date: datetime-like object
+        :return: Pandas DataFrame
+        """
+        raise NotImplementedError('Method should be implemented by subclass')
+
 class Weather_Days(Weather):
     """
         Weather_Days object contains a Pandas DataFrame with all weather data 
@@ -313,7 +322,7 @@ class Weather_Hours(Weather):
         """
         #get forecast
         forecast = self._get_forecast(date=date)
-        
+
         #create a Pandas Series per hour
         day_data = forecast.hourly().data
         hourlist = [pd.Series(hour.d) for hour in day_data]

--- a/library/forecastwrapper.py
+++ b/library/forecastwrapper.py
@@ -11,7 +11,6 @@ from copy import copy
 
 class Weather(object):
     """
-        Abstract Class
         Object that contains Weather Data from Forecast.io for multiple days as a Pandas Dataframe.
         Use Weather_Days and Weather_Hours for different resolutions.
 
@@ -48,6 +47,14 @@ class Weather(object):
         self.location = self.geolocator.geocode(self._location)
 
         self.df = self.get_weather_df(start, end, tz)
+
+    def _get_forecast(self, date):
+        """
+        Get the raw forecast object for a given date
+        :param date: datetime-like object
+        :return: forecastio forecast
+        """
+        return forecastio.load_forecast(self.api_key, self.location.latitude, self.location.longitude, date)
 
     def _dayset(self, start, end):
         """
@@ -191,7 +198,7 @@ class Weather_Days(Weather):
             Pandas Dataframe
         """
         #get forecast
-        forecast = forecastio.load_forecast(self.api_key, self.location.latitude, self.location.longitude, date)
+        forecast = self._get_forecast(date=date)
         day_data = forecast.daily().data[0].d
 
         #calculate average temperature and add to day_data
@@ -305,8 +312,8 @@ class Weather_Hours(Weather):
             Pandas Dataframe
         """
         #get forecast
-        forecast = forecastio.load_forecast(self.api_key, self.location.latitude, self.location.longitude, date)
-
+        forecast = self._get_forecast(date=date)
+        
         #create a Pandas Series per hour
         day_data = forecast.hourly().data
         hourlist = [pd.Series(hour.d) for hour in day_data]

--- a/library/forecastwrapperV2.py
+++ b/library/forecastwrapperV2.py
@@ -1,0 +1,414 @@
+__author__ = 'Jan Pecinovsky'
+
+import datetime as dt
+from copy import copy
+
+import forecastio
+import geopy
+import numpy as np
+import pandas as pd
+from dateutil import rrule
+
+
+class Weather():
+    """
+        Object that contains Weather Data from Forecast.io for multiple days as a Pandas Dataframe.
+        NOTE: Forecast.io allows 1000 requests per day, after that you have to pay. Each requested day is 1 request.
+    """
+
+    def __init__(self, api_key, location, start, end=None, tz=None):
+        """
+            Constructor
+
+            Parameters
+            ----------
+            api_key : string
+                Forecast.io API Key
+            location : string OR iterable with 2 floats, latitude and longitude
+                String can be City, address, POI. Iterable = [lat,lng]
+            start : datetime-like object
+                start of the interval to be searched
+            end : datetime-like object (optional, default=None)
+                end of the interval to be searched, if None, use current time
+            tz : timezone string (optional)
+                tz specifies the timezone of the response.
+                If none, response will be in the timezone of the location
+        """
+
+        self.start = start
+        if end is None:
+            end = pd.Timestamp('now', tz=tz)
+        self.end = end
+
+        self.api_key = api_key
+
+        # input location
+        if isinstance(location, str):
+            self.location = self._get_geolocator().geocode(location)
+        else:
+            self.location = geopy.location.Location(
+                point=geopy.location.Point(latitude=location[0], longitude=location[1]))
+
+        if tz is not None:
+            self.tz = tz
+        else:
+            self.tz = self.lookup_timezone()
+
+        self.forecasts = [self._get_forecast(date=date) for date in self._dayset(start=start, end=end)]
+
+    def days(self,
+             include_average_temperature=True,
+             include_temperature_equivalent=True,
+             include_heating_degree_days=True,
+             heating_base_temperatures=[16.5],
+             include_cooling_degree_days=True,
+             cooling_base_temperatures=[18],
+             include_daytime_cloud_cover=True,
+             include_daytime_temperature=True
+             ):
+        """
+        Create a dataframe with all weather data in daily resolution
+
+        Parameters
+        ----------
+        include_average_temperature : bool (optional, default: True)
+            Include automatic calculation of average temperature from hourly data
+        include_temperature_equivalent : bool (optional, default: True)
+            Include Temperature Equivalent to dataframe
+        include_heating_degree_days : bool (optional, default: True)
+            Add heating degree days to the dataframe
+        heating_base_temperatures : list of numbers (optional, default 16.5)
+            List of possible base temperatures for which to calculate heating degree days
+        include_cooling_degree_days : bool (optional, default: False)
+            Add cooling degree days to the dataframe
+        cooling_base_temperatures : list of numbers (optional, default 18)
+            List of possible base temperatures for which to calculate cooling degree days
+        include_daytime_cloud_cover : bool (optional, default: True)
+            Include average Cloud Cover during daytime hours (from sunrise to sunset)
+        include_daytime_temperature : bool (optional, default: True)
+            Include average Temperature during daytime hours (from sunrise to sunset)
+
+        Returns
+        -------
+        Pandas Dataframe
+        """
+        if include_heating_degree_days or include_cooling_degree_days:
+            include_temperature_equivalent = True
+
+        if include_temperature_equivalent:
+            include_average_temperature = True
+
+        # if temperature_equivalent is needed,
+        # we need to add 2 days before the start
+        if include_temperature_equivalent:
+            self._add_forecast(self.start - pd.Timedelta(days=1))
+            self._add_forecast(self.start - pd.Timedelta(days=2))
+
+        day_list = [self._forecast_to_day_series(forecast=forecast,
+                                                 include_average_temperature=include_average_temperature,
+                                                 include_daytime_cloud_cover=include_daytime_cloud_cover,
+                                                 include_daytime_temperature=include_daytime_temperature
+                                                 ) for forecast in self.forecasts]
+
+        frame = pd.concat(day_list)
+        frame = self._fix_index(frame).sort()
+
+        if include_temperature_equivalent:
+            frame = self._add_temperature_equivalent(frame)
+
+        if include_heating_degree_days:
+            frame = self._add_heating_degree_days(df=frame, base_temperatures=heating_base_temperatures)
+
+        if include_cooling_degree_days:
+            frame = self._add_cooling_degree_days(df=frame, base_temperatures=cooling_base_temperatures)
+
+        return frame.truncate(before=self.start, after=self.end)
+
+    def hours(self):
+        """
+        Create a dataframe with all weather data in hourly resolution
+
+        Returns
+        -------
+        Pandas Dataframe
+        """
+        day_list = [self._forecast_to_hour_series(forecast) for forecast in self.forecasts]
+        frame = pd.concat(day_list)
+        return self._fix_index(frame).truncate(before=self.start, after=self.end)
+
+    def _get_geolocator(self):
+        """
+            Only create the geolocator if needed
+
+            Returns
+            -------
+            geopy.geolocator
+        """
+        if not hasattr(self, 'geolocator'):
+            self.geolocator = geopy.GoogleV3()
+        return self.geolocator
+
+    def _dayset(self, start, end):
+        """
+            Takes a start and end date and returns a set containing all dates between start and end
+
+            Parameters
+            ----------
+            start : datetime-like object
+            end : datetime-like object
+
+            Returns
+            -------
+            set of datetime objects
+        """
+
+        res = []
+        for dt in rrule.rrule(rrule.DAILY, dtstart=start, until=end):
+            res.append(dt)
+        return sorted(set(res))
+
+    def _get_forecast(self, date):
+        """
+            Get the raw forecast object for a given date
+
+            Parameters
+            ----------
+            date : datetime-like object
+
+            Returns
+            -------
+            forecastio forecast
+        """
+        return forecastio.load_forecast(self.api_key, self.location.latitude, self.location.longitude, date)
+
+    def _get_forecast_dates(self):
+        """
+        Return a set with the dates of all forecasts in self.forecasts
+
+        Returns
+        -------
+        set of datetime.date
+        """
+        return {forecast.currently().time.date() for forecast in self.forecasts}
+
+    def _add_forecast(self, date):
+        """
+        Add a forecast to the list of forecasts
+
+        Parameters
+        ----------
+        date: datetime-like object
+        """
+        if date.date() not in self._get_forecast_dates():
+            self.forecasts.append(self._get_forecast(date))
+
+    def _forecast_to_hour_series(self, forecast):
+        """
+        Transforms the hourly data of a forecast object to a pandas dataframe
+
+        Parameters
+        ----------
+        forecast : Forecast object
+
+        Returns
+        -------
+        Pandas Dataframe
+
+        """
+        hour_list = [pd.Series(hour.d) for hour in forecast.hourly().data]
+        frame = pd.concat(hour_list, axis=1).T
+        return frame
+
+    def _fix_index(self, frame):
+        """
+        Transform a column of a dataframe to a datetimeindex, set as the index and localize
+
+        Parameters
+        ----------
+        frame : Pandas Dataframe
+
+        Returns
+        -------
+        Pandas Dataframe
+
+        """
+        frame['time'] = pd.DatetimeIndex(frame['time'].astype('datetime64[s]'))
+        frame.set_index('time', inplace=True)
+        frame = frame.tz_localize('UTC')
+        frame = frame.tz_convert(self.tz)
+        return frame
+
+    def lookup_timezone(self):
+        """
+        Lookup the timezone using the location information
+
+        Returns
+        -------
+        String (Pytz timezone)
+        """
+        tz = self._get_geolocator().timezone((self.location.latitude, self.location.longitude))
+        return tz.zone
+
+    def _forecast_to_day_series(
+            self,
+            forecast,
+            include_average_temperature,
+            include_daytime_cloud_cover,
+            include_daytime_temperature
+    ):
+        """
+        Transforms the daily data of a forecast object to a pandas dataframe
+
+        Parameters
+        ----------
+        include_daytime_cloud_cover : bool
+        include_daytime_temperature : bool
+        include_average_temperature : bool
+        forecast : Forecast Object
+
+        Returns
+        -------
+        Pandas dataframe
+
+        """
+        data = forecast.daily().data[0].d
+
+        if include_average_temperature:
+            average_temperature = self._get_daily_average(forecast=forecast, key='temperature')
+            data.update({'temperature': average_temperature})
+        if include_daytime_cloud_cover:
+            daytime_cloud_cover = self._get_daytime_average(forecast=forecast, key='cloudCover')
+            data.update({'daytimeCloudCover': daytime_cloud_cover})
+        if include_daytime_temperature:
+            daytime_temperature = self._get_daytime_average(forecast=forecast, key='temperature')
+            data.update({'daytimeTemperature': daytime_temperature})
+
+        frame = [pd.Series(data)]
+        return pd.concat(frame, axis=1).T
+
+    def _get_daily_average(self, forecast, key):
+        """
+        Calculate the average daily value for a given forecast and a given key from the hourly values
+
+        Parameters
+        ----------
+        forecast : Forecast object
+        key : String
+
+        Returns
+        -------
+        float
+        """
+        # make a list of all hourly values for the given key
+        values = [hour.d[key] for hour in forecast.hourly().data]
+        # calculate the mean, round to 2 significant figures and return
+        return round(np.mean(values), 2)
+
+    def _get_daytime_average(self, forecast, key):
+        """
+        Calculate the average for a given value during daytime hours (from sunrise to sunset)
+
+        Parameters
+        ----------
+        forecast : Forecast Object
+        key : String
+
+        Returns
+        -------
+        float
+        """
+        # extract values from forecast
+        try:
+            values = [hour.d[key] for hour in forecast.hourly().data]
+        except KeyError:
+            return None
+
+        # make a time series
+        time = [hour.d['time'] for hour in forecast.hourly().data]
+        ts = pd.Series(data=values, index=time)
+        ts.index = pd.DatetimeIndex(ts.index.astype('datetime64[s]'))
+
+        # get sunrise and sunset
+        sunrise = dt.datetime.utcfromtimestamp(forecast.daily().data[0].d['sunriseTime'])
+        sunset = dt.datetime.utcfromtimestamp(forecast.daily().data[0].d['sunsetTime'])
+
+        # truncate timeseries
+        ts = ts.truncate(before=sunrise, after=sunset)
+
+        # return mean of truncated timeseries
+        return round(ts.mean(), 2)
+
+    def _add_temperature_equivalent(self, df):
+        """
+        Adds the temperature equivalent to the data frame
+        according to the formula: 0.6 * tempDay0 + 0.3 * tempDay-1 + 0.1 * tempDay-2
+        Because we need the two previous days to calculate day0, the resulting dataframe will be 2 days shorter
+        (you should pass dataframes that have two days more than you want)
+
+        Parameters
+        ----------
+        df : Pandas Dataframe
+
+        Returns
+        -------
+        Pandas Dataframe
+        """
+
+        # select temperature column from dataframe
+        temperature = df['temperature']
+        # calculate the temperature equivalent, using two days before day0
+        temperature_equivalent = [
+            0.6 * temperature.values[ix] + 0.3 * temperature.values[ix - 1] + 0.1 * temperature.values[ix - 2] for ix in
+            range(0, len(df)) if ix > 1]
+
+        # the response will be 2 days shorter
+        res = copy(df[2:])
+
+        # add the temperature equivalent to the response
+        res['temperatureEquivalent'] = temperature_equivalent
+
+        return res
+
+    def _add_heating_degree_days(self, df, base_temperatures):
+        """
+        Add heating degree days to the dataframe.
+        They are calculated by subtracting the temperature equivalent from a base temperature
+        Note: Degree days cannot be negative
+
+        Parameters
+        ----------
+        df : Pandas Dataframe
+        base_temperatures : list of numbers
+
+        Returns
+        -------
+        Pandas Dataframe
+        """
+
+        for base in base_temperatures:
+            df['heatingDegreeDays{}'.format(base)] = [max(0, base - equivalent) for equivalent in
+                                                      df['temperatureEquivalent']]
+
+        return df
+
+    def _add_cooling_degree_days(self, df, base_temperatures):
+        """
+        Add cooling degree days to the dataframe.
+        They are calculated by subtracting a base temperature from the temperature equivalent.
+        Note: Degree days cannot be negative
+
+        Parameters
+        ----------
+        df : Pandas Dataframe
+        base_temperatures : list of numbers
+
+        Returns
+        -------
+        Pandas Dataframe
+        """
+
+        for base in base_temperatures:
+            df['coolingDegreeDays{}'.format(base)] = [max(0, equivalent - base) for equivalent in
+                                                      df['temperatureEquivalent']]
+
+        return df

--- a/scripts/Demo_Forecast.ioV2.ipynb
+++ b/scripts/Demo_Forecast.ioV2.ipynb
@@ -1,0 +1,389 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# What's new in the Forecastwrapper V2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "• No more seperate objects `Weather_Days` and `Weather_Hours`, just `Weather`\n",
+    "\n",
+    "• The `Weather` object has methods `days()` and `hours()` which return a dataframe in the desired resolution. (We chose this approach because now you only need 1 call to forecast.io to get both resolutions, in V1 you needed 2 calls if you wanted both)\n",
+    "\n",
+    "• More verbose and pythonicly named arguments. Eg. the flag `heatingDegreeDays` is now called `include_heating_degree_days`\n",
+    "\n",
+    "• The temperature equivalent is now by default included in the daily dataframe. It can be excluded by using the flag `include_temperature_equivalent = False`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Demo of the forecast.io wrapper to get past and future weather data\n",
+    "\n",
+    "Important: you need to register for an apikey here: https://developer.forecast.io/  Put the key you obtain in the opengrid.cfg file as follows:\n",
+    "\n",
+    "    [Forecast.io]\n",
+    "    apikey: your_key"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import os, sys, inspect\n",
+    "import pandas as pd\n",
+    "import charts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# add the sccript path to opengrid to sys.path\n",
+    "script_dir = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))\n",
+    "sys.path.append(os.path.join(script_dir, os.pardir, os.pardir))\n",
+    "\n",
+    "from opengrid.library.config import Config"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get Forecast.io API key from config file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "config = Config()\n",
+    "\n",
+    "#get Forecast.io API Key\n",
+    "api_key = config.get('Forecast.io', 'apikey')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Import API wrapper module"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from opengrid.library import forecastwrapperV2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Get weather data in daily and hourly resolution"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To get started, create a Weather object for a certain location and a period"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "start = pd.Timestamp('20150813')\n",
+    "end = pd.Timestamp('20150816')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "Weather_Ukkel = forecastwrapperV2.Weather(api_key=api_key, location='Ukkel', start=start, end=end)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can use the methods `days()` and `hours()` to get a dataframe in daily or hourly resolution"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "Weather_Ukkel.days()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "Weather_Ukkel.hours()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Degree Days"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Daily resolution has the option of adding degree days.\n",
+    "By default, the temperature equivalent and heating degree days with a base temperature of 16.5°C are added.\n",
+    "\n",
+    "Heating degree days are calculated as follows:\n",
+    "\n",
+    "$$heatingDegreeDays = max(0 , baseTemp - 0.6 * T_{today} + 0.3 * T_{today-1} + 0.1 * T_{today-2} )$$\n",
+    "\n",
+    "Cooling degree days are calculated in an analog way:\n",
+    "\n",
+    "$$coolingDegreeDays = max(0, 0.6 * T_{today} + 0.3 * T_{today-1} + 0.1 * T_{today-2} - baseTemp )$$\n",
+    "\n",
+    "Add degree days by setting the flag `include_heating_degree_days` or `include_cooling_degree_days` and supplying `heating_base_temperatures` and/or `cooling_base_temperatures` as a list (you can add multiple base temperatures, or just a list of 1 element)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Get some more degree days"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "Weather_Ukkel.days(include_heating_degree_days = True,\n",
+    "                   heating_base_temperatures = [15,18],\n",
+    "                   include_cooling_degree_days = True,\n",
+    "                   cooling_base_temperatures = [18,24]).filter(like='DegreeDays')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Daytime Averages"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Daily resolution has the option of adding average values during the daytime only (between sunrise and sunset). Implemented are daytimeCloudCover and daytimeTemperature, and are included by default. They can be excluded by setting `include_daytime_cloud_cover = False` or `include_daytime_temperature = False`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "By default, daily weather data is extended with *daytimeCloudCover* and *daytimeTemperature*.  These are the averaged cloud cover and temperature **between sunrise and sunset**. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "Weather_Ukkel.days().filter(like='daytime')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Hourly resolution example"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Location can also be coördinates"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "start = pd.Timestamp('20150916')\n",
+    "end = pd.Timestamp('20150918')\n",
+    "Weather_Brussel = forecastwrapperV2.Weather(api_key=api_key, location=[50.8503396, 4.3517103], start=start, end=end)\n",
+    "Weather_Boutersem = forecastwrapperV2.Weather(api_key=api_key, location='Kapelstraat 1, 3370 Boutersem', start=start, end=end)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "df_combined = pd.merge(Weather_Brussel.hours(), Weather_Boutersem.hours(), suffixes=('_Brussel', '_Boutersem'), \n",
+    "                       left_index=True, right_index=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "charts.plot(df_combined.filter(like='cloud'), stock=True, show='inline')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Deal with different timezones"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "By default, all dataframes are localized to the timezone of the specified location.\n",
+    "If you want, you can specify the tz argument to get all dataframes localized to a specified timezone."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "start = pd.Timestamp('20150815')\n",
+    "end = pd.Timestamp('20150816')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "Weather_London = forecastwrapperV2.Weather(api_key=api_key, location='London', start=start, end=end, tz='Asia/Singapore')\n",
+    "Weather_Brussels = forecastwrapperV2.Weather(api_key=api_key, location='Brussels', start=start, end=end, tz='Asia/Singapore')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "Weather_London.days()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "Weather_Brussels.days()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
We wanted a way to save both daily and hourly weather data, but with the old wrapper you needed 2 calls to Forecast to do this. This update fixes that by using a single object `Weather` which holds all data and methods `days()` and `hours()` to access them.
Some arguments were also renamed to be more verbose and pythonic, so be sure to check out the new demo.