### PR TITLE
Removed pandas 0.18.1 workaround, gave errors with newer versions.

### DIFF
--- a/opengrid/library/houseprint/device.py
+++ b/opengrid/library/houseprint/device.py
@@ -65,10 +65,6 @@ class Device(object):
 
         sensors = self.get_sensors(sensortype)
         series = [sensor.get_data(head=head, tail=tail, diff=diff, resample=resample, unit=unit) for sensor in sensors]
-
-        # workaround for https://github.com/pandas-dev/pandas/issues/12985
-        series = [s for s in series if not s.empty]
-
         df = pd.concat(series, axis=1)
 
         # Add unit as string to each series in the df.  This is not persistent: the attribute unit will get

--- a/opengrid/library/houseprint/houseprint.py
+++ b/opengrid/library/houseprint/houseprint.py
@@ -471,10 +471,6 @@ class Houseprint(object):
         if sensors is None:
             sensors = self.get_sensors(sensortype)
         series = [sensor.get_data(head=head, tail=tail, diff=diff, resample=resample, unit=unit) for sensor in sensors]
-
-        # workaround for https://github.com/pandas-dev/pandas/issues/12985
-        series = [s for s in series if not s.empty]
-
         df = pd.concat(series, axis=1)
 
         # Add unit as string to each series in the df.  This is not persistent: the attribute unit will get

--- a/opengrid/library/houseprint/site.py
+++ b/opengrid/library/houseprint/site.py
@@ -75,10 +75,6 @@ class Site(object):
         """
         sensors = self.get_sensors(sensortype)
         series = [sensor.get_data(head=head, tail=tail, diff=diff, resample=resample, unit=unit) for sensor in sensors]
-
-        # workaround for https://github.com/pandas-dev/pandas/issues/12985
-        series = [s for s in series if not s.empty]
-
         df = pd.concat(series, axis=1)
 
         # Add unit as string to each series in the df.  This is not persistent: the attribute unit will get


### PR DESCRIPTION
Installed pandas 0.19.1, the workaround code gave an error because the .concat bug is fixed from version 0.18.1+