### PR TITLE
Get last timestamp for sensor

### DIFF
--- a/opengrid/library/houseprint/device.py
+++ b/opengrid/library/houseprint/device.py
@@ -97,6 +97,25 @@ class Device(object):
         """
         return len(self.get_sensors(sensortype=sensortype))
 
+    def last_timestamp(self, epoch=False):
+        """
+        Get the last timestamp for a device, by returning the latest timestamp
+        of the sensors
+
+        Parameters
+        ----------
+        epoch : bool
+            default False
+            If True return as epoch
+            If False return as pd.Timestamp
+
+        Returns
+        -------
+        pd.Timestamp | int
+        """
+        timestamps = [sensor.last_timestamp(epoch=epoch) for sensor in self.sensors]
+        return max(timestamps)
+
 
 class Fluksometer(Device):
     def __init__(self, site, key, mastertoken = None):

--- a/opengrid/library/houseprint/sensor.py
+++ b/opengrid/library/houseprint/sensor.py
@@ -166,6 +166,23 @@ class Sensor(object):
                 source = str(q_int.units) + '/' + resample
             return CALORIFICVALUE * misc.unit_conversion_factor(source, target)
 
+    def last_timestamp(self, epoch=False):
+        """
+        Get the last timestamp for a sensor
+
+        Parameters
+        ----------
+        epoch : bool
+            default False
+            If True return as epoch
+            If False return as pd.Timestamp
+
+        Returns
+        -------
+        pd.Timestamp | int
+        """
+        raise NotImplementedError("Subclass must implement abstract method")
+
 
 class Fluksosensor(Sensor):
     def __init__(self, key, token, device, type, description, system, quantity, unit, direction, tariff, cumulative):


### PR DESCRIPTION
Ported a piece of TMPO code to the houseprint, it should be replaced as
soon as the last_timestamp method is pulled there.

Do `sensor.last_timestamp()` to get the end of the last TMPO-block that
is found for that sensor, or `device.last_timestamp()` to get the last timestamp for the device.

@WolfBerwouts I have also added a `last_timestamp()` method on the device level, so you can deal with inactive gas sensors by checking if their 'brothers and sisters' are also inactive or not.